### PR TITLE
Add proper MIT LICENSE file and fix license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Luke Dary and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -448,4 +448,4 @@ src/
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "paa-pub",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "description": "Single-user Solid + ActivityPub server on Cloudflare Workers",
   "scripts": {
     "dev": "wrangler dev",


### PR DESCRIPTION
## Summary

- Add full MIT LICENSE file (copyright Luke Dary and contributors)
- Add `"license": "MIT"` field to `package.json`
- Update README license section to link to the LICENSE file

Closes #1

## Note

Some dependencies (`@s20e/*`) use LGPL-3.0-or-later. This is noted in the issue for future consideration.